### PR TITLE
Fix warnings

### DIFF
--- a/kerdb/kerdb/KerDB.m
+++ b/kerdb/kerdb/KerDB.m
@@ -6,7 +6,7 @@
 //  Copyright © 2016年 com.kercer. All rights reserved.
 //
 
-#import "KerDB.h"
+#import "kerdb.h"
 #import "KCCommon.h"
 
 

--- a/kerdb/leveldb/db/db_impl.cc
+++ b/kerdb/leveldb/db/db_impl.cc
@@ -1080,7 +1080,7 @@ Iterator* DBImpl::NewInternalIterator(const ReadOptions& options,
   }
   versions_->current()->AddIterators(options, &list);
   Iterator* internal_iter =
-      NewMergingIterator(&internal_comparator_, &list[0], list.size());
+      NewMergingIterator(&internal_comparator_, &list[0], (int)list.size());
   versions_->current()->Ref();
 
   cleanup->mu = &mutex_;

--- a/kerdb/leveldb/db/dbformat.cc
+++ b/kerdb/leveldb/db/dbformat.cc
@@ -128,7 +128,7 @@ LookupKey::LookupKey(const Slice& user_key, SequenceNumber s) {
     dst = new char[needed];
   }
   start_ = dst;
-  dst = EncodeVarint32(dst, usize + 8);
+  dst = EncodeVarint32(dst, (uint32_t)(usize + 8));
   kstart_ = dst;
   memcpy(dst, user_key.data(), usize);
   dst += usize;

--- a/kerdb/leveldb/db/memtable.cc
+++ b/kerdb/leveldb/db/memtable.cc
@@ -43,7 +43,7 @@ int MemTable::KeyComparator::operator()(const char* aptr, const char* bptr)
 // into this scratch space.
 static const char* EncodeKey(std::string* scratch, const Slice& target) {
   scratch->clear();
-  PutVarint32(scratch, target.size());
+  PutVarint32(scratch, (uint32_t)target.size());
   scratch->append(target.data(), target.size());
   return scratch->data();
 }
@@ -94,12 +94,12 @@ void MemTable::Add(SequenceNumber s, ValueType type,
       VarintLength(internal_key_size) + internal_key_size +
       VarintLength(val_size) + val_size;
   char* buf = arena_.Allocate(encoded_len);
-  char* p = EncodeVarint32(buf, internal_key_size);
+  char* p = EncodeVarint32(buf, (uint32_t)internal_key_size);
   memcpy(p, key.data(), key_size);
   p += key_size;
   EncodeFixed64(p, (s << 8) | type);
   p += 8;
-  p = EncodeVarint32(p, val_size);
+  p = EncodeVarint32(p, (uint32_t)val_size);
   memcpy(p, value.data(), val_size);
   assert((p + val_size) - buf == encoded_len);
   table_.Insert(buf);

--- a/kerdb/leveldb/db/version_set.cc
+++ b/kerdb/leveldb/db/version_set.cc
@@ -1022,7 +1022,7 @@ bool VersionSet::ReuseManifest(const std::string& dscname,
   }
   FileType manifest_type;
   uint64_t manifest_number;
-  uint64_t manifest_size;
+  uint64_t manifest_size = 0;
   if (!ParseFileName(dscbase, &manifest_number, &manifest_type) ||
       manifest_type != kDescriptorFile ||
       !env_->GetFileSize(dscname, &manifest_size).ok() ||

--- a/kerdb/leveldb/db/version_set.cc
+++ b/kerdb/leveldb/db/version_set.cc
@@ -78,7 +78,7 @@ int FindFile(const InternalKeyComparator& icmp,
              const std::vector<FileMetaData*>& files,
              const Slice& key) {
   uint32_t left = 0;
-  uint32_t right = files.size();
+  uint32_t right = (uint32_t)files.size();
   while (left < right) {
     uint32_t mid = (left + right) / 2;
     const FileMetaData* f = files[mid];
@@ -157,7 +157,7 @@ class Version::LevelFileNumIterator : public Iterator {
                        const std::vector<FileMetaData*>* flist)
       : icmp_(icmp),
         flist_(flist),
-        index_(flist->size()) {        // Marks as invalid
+        index_((uint32_t)flist->size()) {        // Marks as invalid
   }
   virtual bool Valid() const {
     return index_ < flist_->size();
@@ -167,7 +167,7 @@ class Version::LevelFileNumIterator : public Iterator {
   }
   virtual void SeekToFirst() { index_ = 0; }
   virtual void SeekToLast() {
-    index_ = flist_->empty() ? 0 : flist_->size() - 1;
+    index_ = flist_->empty() ? 0 : (uint32_t)(flist_->size() - 1);
   }
   virtual void Next() {
     assert(Valid());
@@ -176,7 +176,7 @@ class Version::LevelFileNumIterator : public Iterator {
   virtual void Prev() {
     assert(Valid());
     if (index_ == 0) {
-      index_ = flist_->size();  // Marks as invalid
+      index_ = (uint32_t)flist_->size();  // Marks as invalid
     } else {
       index_--;
     }
@@ -690,7 +690,7 @@ class VersionSet::Builder {
       // same as the compaction of 40KB of data.  We are a little
       // conservative and allow approximately one seek for every 16KB
       // of data before triggering a compaction.
-      f->allowed_seeks = (f->file_size / 16384);
+      f->allowed_seeks = (int)(f->file_size / 16384);
       if (f->allowed_seeks < 100) f->allowed_seeks = 100;
 
       levels_[level].deleted_files.erase(f->number);
@@ -1122,7 +1122,7 @@ Status VersionSet::WriteSnapshot(log::Writer* log) {
 int VersionSet::NumLevelFiles(int level) const {
   assert(level >= 0);
   assert(level < config::kNumLevels);
-  return current_->files_[level].size();
+  return (int)current_->files_[level].size();
 }
 
 const char* VersionSet::LevelSummary(LevelSummaryStorage* scratch) const {
@@ -1253,7 +1253,7 @@ Iterator* VersionSet::MakeInputIterator(Compaction* c) {
   // Level-0 files have to be merged together.  For other levels,
   // we will make a concatenating iterator per level.
   // TODO(opt): use concatenating iterator for level-0 if there is no overlap
-  const int space = (c->level() == 0 ? c->inputs_[0].size() + 1 : 2);
+  const int space = (int)(c->level() == 0 ? c->inputs_[0].size() + 1 : 2);
   Iterator** list = new Iterator*[space];
   int num = 0;
   for (int which = 0; which < 2; which++) {

--- a/kerdb/leveldb/db/version_set.h
+++ b/kerdb/leveldb/db/version_set.h
@@ -108,7 +108,7 @@ class Version {
   int PickLevelForMemTableOutput(const Slice& smallest_user_key,
                                  const Slice& largest_user_key);
 
-  int NumFiles(int level) const { return files_[level].size(); }
+  int NumFiles(int level) const { return (int)files_[level].size(); }
 
   // Return a human readable string that describes this version's contents.
   std::string DebugString() const;
@@ -334,7 +334,7 @@ class Compaction {
   VersionEdit* edit() { return &edit_; }
 
   // "which" must be either 0 or 1
-  int num_input_files(int which) const { return inputs_[which].size(); }
+  int num_input_files(int which) const { return (int)inputs_[which].size(); }
 
   // Return the ith input file at "level()+which" ("which" must be 0 or 1).
   FileMetaData* input(int which, int i) const { return inputs_[which][i]; }

--- a/kerdb/leveldb/table/block.cc
+++ b/kerdb/leveldb/table/block.cc
@@ -93,7 +93,7 @@ class Block::Iter : public Iterator {
 
   // Return the offset in data_ just past the end of the current entry.
   inline uint32_t NextEntryOffset() const {
-    return (value_.data() + value_.size()) - data_;
+    return (uint32_t)((value_.data() + value_.size()) - data_);
   }
 
   uint32_t GetRestartPoint(uint32_t index) {

--- a/kerdb/leveldb/table/block.cc
+++ b/kerdb/leveldb/table/block.cc
@@ -32,7 +32,7 @@ Block::Block(const BlockContents& contents)
       // The size is too small for NumRestarts()
       size_ = 0;
     } else {
-      restart_offset_ = size_ - (1 + NumRestarts()) * sizeof(uint32_t);
+      restart_offset_ = (uint32_t)(size_ - (1 + NumRestarts()) * sizeof(uint32_t));
     }
   }
 }

--- a/kerdb/leveldb/table/block_builder.cc
+++ b/kerdb/leveldb/table/block_builder.cc
@@ -85,7 +85,7 @@ void BlockBuilder::Add(const Slice& key, const Slice& value) {
     }
   } else {
     // Restart compression
-    restarts_.push_back(buffer_.size());
+    restarts_.push_back((unsigned int)buffer_.size());
     counter_ = 0;
   }
   const size_t non_shared = key.size() - shared;

--- a/kerdb/leveldb/table/block_builder.cc
+++ b/kerdb/leveldb/table/block_builder.cc
@@ -65,7 +65,7 @@ Slice BlockBuilder::Finish() {
   for (size_t i = 0; i < restarts_.size(); i++) {
     PutFixed32(&buffer_, restarts_[i]);
   }
-  PutFixed32(&buffer_, restarts_.size());
+  PutFixed32(&buffer_, (uint32_t)restarts_.size());
   finished_ = true;
   return Slice(buffer_);
 }

--- a/kerdb/leveldb/table/block_builder.cc
+++ b/kerdb/leveldb/table/block_builder.cc
@@ -91,9 +91,9 @@ void BlockBuilder::Add(const Slice& key, const Slice& value) {
   const size_t non_shared = key.size() - shared;
 
   // Add "<shared><non_shared><value_size>" to buffer_
-  PutVarint32(&buffer_, shared);
-  PutVarint32(&buffer_, non_shared);
-  PutVarint32(&buffer_, value.size());
+  PutVarint32(&buffer_, (uint32_t)shared);
+  PutVarint32(&buffer_, (uint32_t)non_shared);
+  PutVarint32(&buffer_, (uint32_t)value.size());
 
   // Add string delta to buffer_ followed by value
   buffer_.append(key.data() + shared, non_shared);

--- a/kerdb/leveldb/table/filter_block.cc
+++ b/kerdb/leveldb/table/filter_block.cc
@@ -39,7 +39,7 @@ Slice FilterBlockBuilder::Finish() {
   }
 
   // Append array of per-filter offsets
-  const uint32_t array_offset = result_.size();
+  const uint32_t array_offset = (uint32_t)result_.size();
   for (size_t i = 0; i < filter_offsets_.size(); i++) {
     PutFixed32(&result_, filter_offsets_[i]);
   }

--- a/kerdb/leveldb/table/filter_block.cc
+++ b/kerdb/leveldb/table/filter_block.cc
@@ -53,7 +53,7 @@ void FilterBlockBuilder::GenerateFilter() {
   const size_t num_keys = start_.size();
   if (num_keys == 0) {
     // Fast path if there are no keys for this filter
-    filter_offsets_.push_back(result_.size());
+    filter_offsets_.push_back((unsigned int)result_.size());
     return;
   }
 
@@ -67,7 +67,7 @@ void FilterBlockBuilder::GenerateFilter() {
   }
 
   // Generate filter for current set of keys and append to result_.
-  filter_offsets_.push_back(result_.size());
+  filter_offsets_.push_back((unsigned int)result_.size());
   policy_->CreateFilter(&tmp_keys_[0], static_cast<int>(num_keys), &result_);
 
   tmp_keys_.clear();

--- a/kerdb/leveldb/util/coding.cc
+++ b/kerdb/leveldb/util/coding.cc
@@ -96,7 +96,7 @@ void PutVarint64(std::string* dst, uint64_t v) {
 }
 
 void PutLengthPrefixedSlice(std::string* dst, const Slice& value) {
-  PutVarint32(dst, value.size());
+  PutVarint32(dst, (uint32_t)value.size());
   dst->append(value.data(), value.size());
 }
 

--- a/kerdb/leveldb/util/env_posix.cc
+++ b/kerdb/leveldb/util/env_posix.cc
@@ -58,7 +58,7 @@ class PosixSequentialFile: public SequentialFile {
   }
 
   virtual Status Skip(uint64_t n) {
-    if (fseek(file_, n, SEEK_CUR)) {
+    if (fseek(file_, (long)n, SEEK_CUR)) {
       return IOError(filename_, errno);
     }
     return Status::OK();
@@ -320,9 +320,9 @@ class PosixEnv : public Env {
       uint64_t size;
       s = GetFileSize(fname, &size);
       if (s.ok()) {
-        void* base = mmap(NULL, size, PROT_READ, MAP_SHARED, fd, 0);
+        void* base = mmap(NULL, (size_t)size, PROT_READ, MAP_SHARED, fd, 0);
         if (base != MAP_FAILED) {
-          *result = new PosixMmapReadableFile(fname, base, size, &mmap_limit_);
+          *result = new PosixMmapReadableFile(fname, base, (size_t)size, &mmap_limit_);
         } else {
           s = IOError(fname, errno);
         }

--- a/kerdb/leveldb/util/hash.cc
+++ b/kerdb/leveldb/util/hash.cc
@@ -20,7 +20,7 @@ uint32_t Hash(const char* data, size_t n, uint32_t seed) {
   const uint32_t m = 0xc6a4a793;
   const uint32_t r = 24;
   const char* limit = data + n;
-  uint32_t h = seed ^ (n * m);
+  uint32_t h = (uint32_t)(seed ^ (n * m));
 
   // Pick up four bytes at a time
   while (data + 4 <= limit) {

--- a/kerdb/leveldb/util/status.cc
+++ b/kerdb/leveldb/util/status.cc
@@ -18,8 +18,8 @@ const char* Status::CopyState(const char* state) {
 
 Status::Status(Code code, const Slice& msg, const Slice& msg2) {
   assert(code != kOk);
-  const uint32_t len1 = msg.size();
-  const uint32_t len2 = msg2.size();
+  const uint32_t len1 = (uint32_t)msg.size();
+  const uint32_t len2 = (uint32_t)msg2.size();
   const uint32_t size = len1 + (len2 ? (2 + len2) : 0);
   char* result = new char[size + 5];
   memcpy(result, &size, sizeof(size));

--- a/kerdb/snappy/snappy.cc
+++ b/kerdb/snappy/snappy.cc
@@ -564,7 +564,7 @@ static uint16 MakeEntry(unsigned int extra,
   return len | (copy_offset << 8) | (extra << 11);
 }
 
-static void ComputeTable() {
+__unused static void ComputeTable() {
   uint16 dst[256];
 
   // Place invalid entries in all places to detect missing initialization

--- a/kerdb/snappy/snappy.cc
+++ b/kerdb/snappy/snappy.cc
@@ -265,7 +265,7 @@ uint16* WorkingMemory::GetHashTable(size_t input_size, int* table_size) {
     table = large_table_;
   }
 
-  *table_size = htsize;
+  *table_size = (int)htsize;
   memset(table, 0, htsize * sizeof(*table));
   return table;
 }

--- a/kerdb/snappy/snappy.cc
+++ b/kerdb/snappy/snappy.cc
@@ -295,7 +295,7 @@ static inline EightBytesReference GetEightBytesAt(const char* ptr) {
 static inline uint32 GetUint32AtOffset(uint64 v, int offset) {
   assert(offset >= 0);
   assert(offset <= 4);
-  return v >> (LittleEndian::IsLittleEndian() ? 8 * offset : 32 - 8 * offset);
+  return (uint32)(v >> (LittleEndian::IsLittleEndian() ? 8 * offset : 32 - 8 * offset));
 }
 
 #else
@@ -400,7 +400,7 @@ char* CompressFragment(const char* input,
       // than 4 bytes match.  But, prior to the match, input
       // bytes [next_emit, ip) are unmatched.  Emit them as "literal bytes."
       assert(next_emit + 16 <= ip_end);
-      op = EmitLiteral(op, next_emit, ip - next_emit, true);
+      op = EmitLiteral(op, next_emit, (int)(ip - next_emit), true);
 
       // Step 3: Call EmitCopy, and then see if another EmitCopy could
       // be our next move.  Repeat until we find no match for the
@@ -446,7 +446,7 @@ char* CompressFragment(const char* input,
  emit_remainder:
   // Emit the remaining bytes as a literal
   if (next_emit < ip_end) {
-    op = EmitLiteral(op, next_emit, ip_end - next_emit, false);
+    op = EmitLiteral(op, next_emit, (int)(ip_end - next_emit), false);
   }
 
   return op;
@@ -757,7 +757,7 @@ class SnappyDecompressor {
           size_t n;
           ip = reader_->Peek(&n);
           avail = n;
-          peeked_ = avail;
+          peeked_ = (uint32)avail;
           if (avail == 0) return;  // Premature end of input
           ip_limit_ = ip + avail;
         }
@@ -794,7 +794,7 @@ bool SnappyDecompressor::RefillTag() {
     reader_->Skip(peeked_);   // All peeked bytes are used up
     size_t n;
     ip = reader_->Peek(&n);
-    peeked_ = n;
+    peeked_ = (uint32)n;
     if (n == 0) {
       eof_ = true;
       return false;
@@ -810,7 +810,7 @@ bool SnappyDecompressor::RefillTag() {
   assert(needed <= sizeof(scratch_));
 
   // Read more bytes from reader if needed
-  uint32 nbuf = ip_limit_ - ip;
+  uint32 nbuf = (uint32)(ip_limit_ - ip);
   if (nbuf < needed) {
     // Stitch together bytes from ip and reader to form the word
     // contents.  We store the needed bytes in "scratch_".  They
@@ -823,7 +823,7 @@ bool SnappyDecompressor::RefillTag() {
       size_t length;
       const char* src = reader_->Peek(&length);
       if (length == 0) return false;
-      uint32 to_add = min<uint32>(needed - nbuf, length);
+      uint32 to_add = min<uint32>(needed - nbuf, (uint32)length);
       memcpy(scratch_ + nbuf, src, to_add);
       nbuf += to_add;
       reader_->Skip(to_add);
@@ -875,7 +875,7 @@ size_t Compress(Source* reader, Sink* writer) {
   size_t written = 0;
   size_t N = reader->Available();
   char ulength[Varint::kMax32];
-  char* p = Varint::Encode32(ulength, N);
+  char* p = Varint::Encode32(ulength, (uint32)N);
   writer->Append(ulength, p-ulength);
   written += (p - ulength);
 
@@ -925,7 +925,7 @@ size_t Compress(Source* reader, Sink* writer) {
     uint16* table = wmem.GetHashTable(num_to_read, &table_size);
 
     // Compress input_fragment and append to dest
-    const int max_output = MaxCompressedLength(num_to_read);
+    const int max_output = (int)MaxCompressedLength(num_to_read);
 
     // Need a scratch buffer for the output, in case the byte sink doesn't
     // have room for us directly.


### PR DESCRIPTION
Fix some buildtime issue, Now the compiler has no warning.

I has fixed 4 types of warnings:
Value conversion issue
Lexical or preprocessor issue
Unused entity issue
Semantic Issue